### PR TITLE
Added support for more paths in `pms add`

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -4,6 +4,7 @@ Copyright © 2023 NAME HERE <EMAIL ADDRESS>
 package cmd
 
 import (
+	"errors"
 	"os"
 
 	"github.com/JammUtkarsh/pms/utils"
@@ -27,12 +28,11 @@ If no argument is provided, the current directory will be added to the list.
 			if err != nil {
 				cobra.CheckErr(err)
 			}
-			cobra.CheckErr(utils.AddProject([]byte(wd)))
+			cobra.CheckErr(utils.AddProject(wd))
 		} else if len(args) == 1 {
-			// User provides a path to the project; Could be relative path or absolute path
+			pathResolver(args[0])
 		} else {
-			// Invalid number of arguments
-
+			cobra.CheckErr(errors.New("Too many arguments provided"))
 		}
 	},
 }
@@ -49,4 +49,19 @@ func init() {
 	// Cobra supports local flags which will only run when this command
 	// is called directly, e.g.:
 	// addCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+}
+
+func pathResolver(path string) string {
+
+	switch {
+	case path[0] == '.' && len(path) == 1:
+		wd, err := os.Getwd()
+		if err != nil {
+			cobra.CheckErr(err)
+		}
+		cobra.CheckErr(utils.AddProject(wd))
+	default:
+		cobra.CheckErr(utils.AddProject(path))
+	}
+	return path
 }

--- a/utils/config.go
+++ b/utils/config.go
@@ -18,7 +18,7 @@ func init() {
 	if _, err := os.Stat(ConfigPath()); os.IsNotExist(err) {
 		// Write default config
 		if _, err := os.Create(ConfigPath()); err == nil {
-			byteData, err := json.MarshalIndent(config{"code",[]Project{},}, "", "    ")
+			byteData, err := json.MarshalIndent(config{"code", []Project{}}, "", "    ")
 			if err != nil {
 				cobra.CheckErr(err)
 			}
@@ -63,14 +63,14 @@ func readConfig() (c config) {
 }
 
 // AddProject adds JSON representation of new project in ~/.pms.json
-func AddProject(workingPath []byte) error {
+func AddProject(workingPath string) error {
 	config := readConfig()
 
-	directories := strings.Split(string(workingPath), "/")
+	directories := strings.Split(workingPath, "/")
 
 	var newProject Project = Project{
-		ProjectName: strings.Split(string(workingPath), string(os.PathSeparator))[len(directories)-1],
-		ProjectPath: string(workingPath),
+		ProjectName: strings.Split(workingPath, string(os.PathSeparator))[len(directories)-1],
+		ProjectPath: workingPath,
 	}
 
 	config.Projects = append(config.Projects, newProject)


### PR DESCRIPTION
Paths includes

- absolute paths like '/user/root/'
- relative path like '.' & '~/path/to/project'.

Paths like '../../path/to/project' is trivial and not yet supported.