### PR TITLE
Fix: duplicate entries on running add subcommand multiple times

### DIFF
--- a/utils/config.go
+++ b/utils/config.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"encoding/json"
+	"errors"
 	"os"
 	"strings"
 
@@ -126,12 +127,17 @@ func AddProject(workingPath string) error {
 		ProjectPath: workingPath,
 	}
 
+	for _, p := range c.Projects {
+		if p.ProjectPath == newProject.ProjectPath {
+			return errors.New("project already exists")
+		}
+	}
+
 	c.Projects = append(c.Projects, newProject)
 	byteData, err := json.MarshalIndent(c, "", "    ")
 	if err != nil {
 		return err
 	}
-
 	return os.WriteFile(ConfigPath(), byteData, 0777)
 }
 


### PR DESCRIPTION
This fixes a bug where running the `add` subcommand multiple times on the same directory would create multiple entries of it. 

It will throw an error `Error: project already exists`.
![out](https://github.com/JammUtkarsh/pms/assets/77291662/37b65dd3-e208-48d7-a0eb-428870c5fecd)
Fixes #7 