### PR TITLE
fix: Display absolute path in TUI for added projects

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -53,14 +53,16 @@ func init() {
 
 func pathResolver(path string) string {
 
+	wd, err := os.Getwd()
+	if err != nil {
+		cobra.CheckErr(err)
+	}
+
 	switch {
 	case path[0] == '.' && len(path) == 1:
-		wd, err := os.Getwd()
-		if err != nil {
-			cobra.CheckErr(err)
-		}
 		cobra.CheckErr(utils.AddProject(wd))
 	default:
+		path = wd + string(os.PathSeparator) + path
 		cobra.CheckErr(utils.AddProject(path))
 	}
 	return path


### PR DESCRIPTION
This commit resolves an issue where the TUI was not showing the absolute path for added projects. The fix involves appending the full path to the project name, ensuring that the absolute path is displayed in the TUI when a project is added.
![out (1)](https://github.com/JammUtkarsh/pms/assets/77291662/d20988e0-15ab-4aa0-9e6d-a86fea219fc1)

fixes #6 