### PR TITLE
feat: add pathFinder function to clean paths

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -6,6 +6,7 @@ package cmd
 import (
 	"errors"
 	"os"
+	"path/filepath"
 
 	"github.com/JammUtkarsh/pms/utils"
 	"github.com/spf13/cobra"
@@ -51,6 +52,11 @@ func init() {
 	// addCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
 }
 
+func pathFinder(path string) string {
+    cleanedPath := filepath.Clean(path)
+    return cleanedPath
+}
+
 func pathResolver(path string) string {
 
 	wd, err := os.Getwd()
@@ -63,6 +69,7 @@ func pathResolver(path string) string {
 		cobra.CheckErr(utils.AddProject(wd))
 	default:
 		path = wd + string(os.PathSeparator) + path
+		path = pathFinder(path)
 		cobra.CheckErr(utils.AddProject(path))
 	}
 	return path

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -1,0 +1,28 @@
+package cmd
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestPathFinder(t *testing.T) {
+	testCases := []struct {
+		path     string
+		expected string
+	}{
+		{filepath.Join("user", "home", "username", "project", "..", "project2"), filepath.Join("user", "home", "username", "project2")},
+		{filepath.Join("user", "..", "home", "username", "project"), filepath.Join("home", "username", "project")},
+		{filepath.Join("user", "home", "username", ".", "project"), filepath.Join("user", "home", "username", "project")},
+		{filepath.Join("user", "home", "username", "project", "..", "..", "project2"), filepath.Join("user", "home", "project2")},
+		{filepath.Join("user", "home", "..", "username", "project", "..", "..", "project2"), filepath.Join("user", "project2")},
+		{filepath.Join("user", "..", "..", "..", "..", "..", "project"), filepath.Join("..", "..", "..", "..", "project")},
+		{filepath.Join("..", "..", ".."), filepath.Join("..", "..", "..")},
+	}
+
+	for _, tc := range testCases {
+		result := pathFinder(tc.path)
+		if result != tc.expected {
+			t.Errorf("pathFinder(%q) = %q; want %q", tc.path, result, tc.expected)
+		}
+	}
+}


### PR DESCRIPTION
This commit introduces a new function, 'pathFinder', which takes a path as input and returns a cleaned version of the path. This function uses the 'filepath.Clean' function from the 'path/filepath' package in Go, which simplifies any '.. or '.' references in the path.