### PR TITLE
feat: add pathFinder function to clean paths

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -6,6 +6,7 @@ package cmd
 import (
 	"errors"
 	"os"
+	"path/filepath"
 
 	"github.com/JammUtkarsh/pms/utils"
 	"github.com/spf13/cobra"
@@ -63,7 +64,7 @@ func pathResolver(path string) string {
 		cobra.CheckErr(utils.AddProject(wd))
 	default:
 		path = wd + string(os.PathSeparator) + path
-		cobra.CheckErr(utils.AddProject(path))
+		cobra.CheckErr(utils.AddProject(filepath.Clean(path)))
 	}
 	return path
 }


### PR DESCRIPTION
Fixes #7 
This commit introduces a new function, `pathFinder`, which takes a path as input and returns a cleaned version of the path. This function uses the `filepath.Clean` function from the `path/filepath` package in Go, which simplifies any `..` or `.` references in the path.
![out](https://github.com/JammUtkarsh/pms/assets/77291662/0b46e71f-dd66-4e73-b2f9-3f2788020f2f)